### PR TITLE
Include SDK docs in sidebar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -44,7 +44,11 @@
               "ai-tools/claude-code",
               "ai-tools/windsurf"
             ]
-          }
+          },
+          {
+            "group": "SDKs",
+            "pages": ["sdk/react"]
+          },
         ]
       },
       {


### PR DESCRIPTION
## Summary
- add React SDK doc to navigation so it shows in the sidebar

## Testing
- `mint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a827d574832cb809b0dcbd9f37fe