### PR TITLE
Add experiment completion docs

### DIFF
--- a/api-reference/endpoint/complete-experiment.mdx
+++ b/api-reference/endpoint/complete-experiment.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Complete Experiment'
+openapi: 'POST /experiments/{experiment_id}/complete'
+---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -93,8 +93,64 @@
                 "$ref": "#/components/schemas/TrackOutcomeRequest"
               }
             }
+      }
+    },
+    "/experiments/{experiment_id}/complete": {
+      "post": {
+        "summary": "Complete Experiment",
+        "operationId": "complete_experiment_experiments__experiment_id__complete_post",
+        "parameters": [
+          {
+            "name": "experiment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Experiment Id"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteExperimentRequest"
+              }
+            }
           }
         },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
         "responses": {
           "201": {
             "description": "Successful Response",
@@ -325,6 +381,17 @@
           "value"
         ],
         "title": "TrackOutcomeRequest"
+      },
+      "CompleteExperimentRequest": {
+        "properties": {
+          "winning_variant_id": {
+            "type": "string",
+            "title": "Winning Variant Id"
+          }
+        },
+        "type": "object",
+        "required": ["winning_variant_id"],
+        "title": "CompleteExperimentRequest"
       },
       "ValidationError": {
         "properties": {

--- a/docs.json
+++ b/docs.json
@@ -49,6 +49,10 @@
             "group": "SDKs",
             "pages": ["sdk/react"]
           },
+          {
+            "group": "Experimentation",
+            "pages": ["experiments/finish-experiment"]
+          },
         ]
       },
       {
@@ -65,7 +69,8 @@
           "pages": [
               "api-reference/endpoint/health",
               "api-reference/endpoint/run-prompt",
-              "api-reference/endpoint/track-outcome"
+              "api-reference/endpoint/track-outcome",
+              "api-reference/endpoint/complete-experiment"
             ]
           }
         ]

--- a/experiments/finish-experiment.mdx
+++ b/experiments/finish-experiment.mdx
@@ -1,0 +1,70 @@
+---
+title: "Finish Experiment Flow"
+description: "Steps to complete an experiment and promote the winning prompt version."
+---
+
+A complete walk-through for closing out a running experiment.
+
+## 1. UI Flow ("Finish Experiment")
+
+1. On `/experiments/[id]`, show a **Finish Experiment** button when the status is `running`.
+2. Clicking the button opens a confirmation modal.
+   - **Title**: "Complete Experiment: Choose Winner"
+   - **Body**: "Select which variant to promote as your new active prompt version. You can review summary metrics for A vs B below."
+   - Allow the user to pick **Variant A** or **Variant B**.
+   - Buttons: **Cancel** or **Complete Experiment**.
+3. When **Complete Experiment** is clicked, send a request to your API endpoint with the winning variant ID.
+4. Provide feedback in the UI:
+   - Show a spinner while completing.
+   - On success, update the page to indicate the experiment is completed and archive the losing variant.
+
+## 2. API Endpoint
+
+```http
+POST /experiments/{experiment_id}/complete
+Content-Type: application/json
+X-API-Key: <org-api-key>
+{
+  "winning_variant_id": "uuid-of-prompt_versions"
+}
+```
+
+The endpoint performs these checks:
+
+1. Ensure the experiment exists and is currently running.
+2. Validate that the `winning_variant_id` is either `variant_a_id` or `variant_b_id`.
+3. In a transaction, mark the experiment as completed and activate the chosen prompt version while archiving the loser.
+4. Optionally, update the prompt to point at the winning version.
+5. Return `200 OK` with the updated experiment.
+
+## 3. Database Changes
+
+Add columns to record the winner and completion time:
+
+```sql
+ALTER TABLE public.experiments
+  ADD COLUMN winning_variant_id UUID REFERENCES public.prompt_versions(id),
+  ADD COLUMN completed_at TIMESTAMP;
+```
+
+Update prompt status workflow and optionally store a `current_version_id` on `prompts`:
+
+```sql
+-- Promote winner and archive loser
+UPDATE prompt_versions
+SET status = 'active'
+WHERE id = :winning_variant_id;
+
+UPDATE prompt_versions
+SET status = 'archived'
+WHERE id IN (:variant_a_id, :variant_b_id)
+  AND id <> :winning_variant_id;
+
+-- Pointer to the newly active version
+ALTER TABLE public.prompts
+  ADD COLUMN current_version_id UUID REFERENCES public.prompt_versions(id);
+```
+
+## 4. Summary
+
+After completion the experiment record stores the winning variant and completion time while the prompt registry automatically points at the new active version.


### PR DESCRIPTION
## Summary
- document how to finish experiments and promote winners
- document new `POST /experiments/{experiment_id}/complete` endpoint
- update OpenAPI specification
- add navigation entry for experimentation docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882ab8fc0f0832c8cc736a5d46e8d07