### PR TITLE
Add get prompt endpoint docs

### DIFF
--- a/api-reference/endpoint/get-prompt.mdx
+++ b/api-reference/endpoint/get-prompt.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Get Prompt'
+openapi: 'POST /get_prompt'
+---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -121,6 +121,55 @@
           }
         }
       }
+    },
+    "/get_prompt": {
+      "post": {
+        "summary": "Get Prompt",
+        "operationId": "get_prompt_get_prompt_post",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunPromptRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPromptResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -363,6 +412,41 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "GetPromptResponse": {
+        "properties": {
+          "prompt_text": {
+            "type": "string",
+            "title": "Prompt Text"
+          },
+          "variant_assigned": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variant Assigned"
+          },
+          "experiment_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Experiment Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt_text"
+        ],
+        "title": "GetPromptResponse"
       }
     }
   }

--- a/docs.json
+++ b/docs.json
@@ -12,11 +12,12 @@
       {
         "tab": "Guides",
         "groups": [
-          
-          
           {
             "group": "SDKs",
-            "pages": ["sdk/react", "sdk/python"]
+            "pages": [
+              "sdk/react",
+              "sdk/python"
+            ]
           }
         ]
       },
@@ -30,10 +31,11 @@
             ]
           },
           {
-          "group": "Endpoint examples",
-          "pages": [
+            "group": "Endpoint examples",
+            "pages": [
               "api-reference/endpoint/health",
               "api-reference/endpoint/run-prompt",
+              "api-reference/endpoint/get-prompt",
               "api-reference/endpoint/track-outcome"
             ]
           }
@@ -47,7 +49,6 @@
           "href": "https://promptstream.ai",
           "icon": "house"
         },
-
         {
           "anchor": "Dashboard",
           "href": "https://app.promptstream.ai",


### PR DESCRIPTION
## Summary
- document `POST /get_prompt` in the API reference
- include new endpoint in navigation
- define GetPromptResponse schema in OpenAPI spec

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884e2bc1670832c8715856ce64fc7fe